### PR TITLE
Токены и редиректы по типам тарифов

### DIFF
--- a/generator/decorators.py
+++ b/generator/decorators.py
@@ -62,8 +62,9 @@ def consume_generation(view_func):
             if not can_gc and not can_oa:
                 return redirect('limit_exceeded_page')
             
-            # Если только OpenAI исчерпан, но GigaChat доступен - показываем специальную страницу
-            if not can_oa and can_gc:
+            # Редирект на openai_limit_exceeded только если OpenAI был в тарифе, но лимит исчерпан.
+            # Для скрытых токенов (openai_tokens_limit == 0) не редиректим — страница генератора с заглушенным OpenAI.
+            if token.openai_tokens_limit > 0 and not can_oa and can_gc:
                 return redirect('openai_limit_exceeded_page')
             
             # Сохраняем токен в request для использования в views

--- a/generator/models.py
+++ b/generator/models.py
@@ -293,7 +293,8 @@ class TemporaryAccessToken(models.Model):
     
     def consume_gigachat_tokens(self, tokens_count):
         """
-        Увеличивает счётчик использованных токенов GigaChat
+        Увеличивает счётчик использованных токенов GigaChat.
+        Для скрытых (HIDDEN_*) и DEVELOPER токенов использование не считается.
         
         Args:
             tokens_count (int): Количество использованных токенов
@@ -301,6 +302,8 @@ class TemporaryAccessToken(models.Model):
         Returns:
             bool: True если успешно, False если превышен лимит
         """
+        if self.token_type in ('HIDDEN_14D', 'HIDDEN_30D', 'DEVELOPER', 'UNLIMITED'):
+            return True  # не считаем для скрытых, разработчика и безлимита
         if self.gigachat_tokens_limit == -1:
             # Безлимит - просто увеличиваем счётчик
             self.gigachat_tokens_used += tokens_count
@@ -316,7 +319,8 @@ class TemporaryAccessToken(models.Model):
     
     def consume_openai_tokens(self, tokens_count):
         """
-        Увеличивает счётчик использованных токенов OpenAI
+        Увеличивает счётчик использованных токенов OpenAI.
+        Для скрытых (HIDDEN_*) и DEVELOPER использование не считается.
         
         Args:
             tokens_count (int): Количество использованных токенов
@@ -324,6 +328,8 @@ class TemporaryAccessToken(models.Model):
         Returns:
             bool: True если успешно, False если превышен лимит
         """
+        if self.token_type in ('HIDDEN_14D', 'HIDDEN_30D', 'DEVELOPER'):
+            return True  # не считаем для скрытых и разработчика
         if self.openai_tokens_limit == -1:
             # Безлимит - просто увеличиваем счётчик
             self.openai_tokens_used += tokens_count


### PR DESCRIPTION
- Редирект на /openai-limit-exceeded только при openai_tokens_limit > 0 (лимит OpenAI исчерпан). Для скрытых тарифов (openai_tokens_limit == 0) редиректа нет — открывается генератор с отключённой кнопкой OpenAI.

- Учёт токенов только для публичных тарифов:
  - consume_gigachat_tokens не считает для HIDDEN_14D, HIDDEN_30D, DEVELOPER и UNLIMITED;
  - consume_openai_tokens не считает для HIDDEN_14D, HIDDEN_30D и DEVELOPER.